### PR TITLE
Fix scraping levels and domain restriction

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ app.config['SECRET_KEY'] = os.getenv('SECRET_KEY')
 def input_url():
     data = request.get_json()
     url = data.get('url')
-    levels = data.get('levels')
+    levels = min(data.get('levels', 1), 3)  # Ensure levels do not exceed 3
     if not url or not levels:
         return jsonify({'error': 'URL and levels are required'}), 400
     scrape_url(url, levels)

--- a/frontend/components/ScraperForm.tsx
+++ b/frontend/components/ScraperForm.tsx
@@ -27,8 +27,9 @@ const ScraperForm = ({ onScrape }) => {
           type="number"
           id="levels"
           value={levels}
-          onChange={(e) => setLevels(e.target.value)}
+          onChange={(e) => setLevels(Math.min(3, e.target.value))}
           min="1"
+          max="3"
           required
         />
       </div>

--- a/scraper.py
+++ b/scraper.py
@@ -2,12 +2,14 @@ import requests
 from bs4 import BeautifulSoup
 from database import save_data
 import os
+from urllib.parse import urlparse, urljoin
 
 def scrape_url(url, levels):
     scraped_data = []
     urls_to_scrape = [(url, 0)]
     scraped_urls = set()
-    max_levels = int(os.getenv('SCRAPING_LEVELS', levels))
+    max_levels = min(3, int(os.getenv('SCRAPING_LEVELS', levels)))
+    domain = urlparse(url).netloc
 
     while urls_to_scrape:
         current_url, current_level = urls_to_scrape.pop(0)
@@ -27,8 +29,8 @@ def scrape_url(url, levels):
 
         if current_level < max_levels:
             for link in soup.find_all('a', href=True):
-                next_url = link['href']
-                if next_url.startswith('http'):
+                next_url = urljoin(current_url, link['href'])
+                if urlparse(next_url).netloc == domain:
                     urls_to_scrape.append((next_url, current_level + 1))
 
     save_data(scraped_data)


### PR DESCRIPTION
Related to #1

Enforce a maximum of 3 levels for URL scraping and ensure only URLs with the same domain are scraped.

* **scraper.py**
  - Enforce a maximum of 3 levels for recursion in the `scrape_url` function.
  - Update the `max_levels` variable to use the minimum of `SCRAPING_LEVELS` and `levels`.
  - Ensure that only URLs with the same domain as the initial URL are scraped.

* **frontend/components/ScraperForm.tsx**
  - Cap the `levels` input to a maximum of 3.

* **app.py**
  - Ensure the `levels` parameter does not exceed 3 in the `input_url` endpoint.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hhayashi-broadtec/chatbot/pull/3?shareId=398d28de-5dbd-4e15-89b9-71a7a870614f).